### PR TITLE
refactor: breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Set key binding to switch between list and tree modes in `keymap.toml`:
 [manager]
 prepend_keymap = [
   { on = [ "E" ], run = "plugin eza-preview",  desc = "Toggle tree/list dir preview" },
-  { on = [ "-" ], run = "plugin eza-preview --args='inc-level'", desc = "Increment tree level" },
-  { on = [ "_" ], run = "plugin eza-preview --args='dec-level'", desc = "Decrement tree level" },
-  { on = [ "$" ], run = "plugin eza-preview --args='toggle-follow-symlinks'", desc = "Toggle tree follow symlinks" },
+  { on = [ "-" ], run = "plugin eza-preview --args='--inc-level'", desc = "Increment tree level" },
+  { on = [ "_" ], run = "plugin eza-preview --args='--dec-level'", desc = "Decrement tree level" },
+  { on = [ "$" ], run = "plugin eza-preview --args='--toggle-follow-symlinks'", desc = "Toggle tree follow symlinks" },
 ]
 ```
 


### PR DESCRIPTION
This pull request includes several changes to improve the handling of job arguments and to standardize the usage of job objects in the `init.lua` file. The key changes involve updating function signatures and replacing direct references to object properties with job object properties. See https://github.com/sxyazi/yazi/pull/1966 for more information.

### Improvements to job argument handling:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L40-R42): Updated key bindings to use double dashes for argument flags in `keymap.toml`.

### Standardization of job object usage:

* [`init.lua`](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7L53-R65): Modified the `entry` function to accept a job object and use its properties instead of directly accessing the arguments.
* [`init.lua`](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7L76-R76): Updated the `peek` function to accept a job object and use its properties for file URL, area height, and skip values. [[1]](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7L76-R76) [[2]](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7L85-R85) [[3]](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7L105-R105) [[4]](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7L119-R119) [[5]](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7L134-R157)
* [`init.lua`](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7L134-R157): Changed the `seek` function to use job object properties for file URL, area height, and units.