### PR TITLE
Make `--all` flag optional

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -18,7 +18,7 @@ end)
 
 local set_opts = ya.sync(function(state, opts)
 	if state.opts == nil then
-		state.opts = { level = 3, follow_symlinks = false, dereference = false }
+		state.opts = { level = 3, follow_symlinks = false, dereference = false, all = true }
 	end
 
 	for key, value in pairs(opts or {}) do
@@ -71,7 +71,6 @@ function M:peek(job)
 	local opts = get_opts()
 
 	local args = {
-		"--all",
 		"--color=always",
 		"--icons=always",
 		"--group-directories-first",
@@ -87,6 +86,10 @@ function M:peek(job)
 	if opts then
 		if opts.follow_symlinks then
 			table.insert(args, "--follow-symlinks")
+		end
+
+		if opts.all then
+			table.insert(args, "--all")
 		end
 
 		if opts.dereference then


### PR DESCRIPTION
I was working on a remote smb filesystem from my mac and got all these dotfiles that were cluttering up the preview and wanted to opt out of seeing hidden files.