### PR TITLE
feat(config): Make default preview mode configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Configure the plugin in `init.lua`:
 
 ```lua
 require("eza-preview"):setup({
+  -- Set the tree preview to be default (default: true)
+  default_tree = true,
+
   -- Directory depth level for tree preview (default: 3)
   level = 3,
 

--- a/main.lua
+++ b/main.lua
@@ -1,62 +1,78 @@
 local M = {}
 
 local function fail(s, ...)
-	ya.notify({ title = "Eza Preview", content = string.format(s, ...), timeout = 5, level = "error" })
+	ya.err({ title = "Eza Preview", content = string.format(s, ...), timeout = 5 })
 end
 
-local toggle_view_mode = ya.sync(function(state, _)
-	if state.tree == nil then
-		state.tree = false
+local function get_or_init_state(state)
+	if state.initialized then
+		return
 	end
+	state.opts = { level = 3, follow_symlinks = false, dereference = false, all = true }
+	state.tree = true
+	state.initialized = true
+end
 
-	state.tree = not state.tree
+local apply_config = ya.sync(function(state, user_config)
+	get_or_init_state(state)
+	user_config = user_config or {}
+	for key, value in pairs(user_config) do
+		if key == "default_tree" then
+			state.tree = value
+		elseif state.opts[key] ~= nil then
+			state.opts[key] = value
+		end
+	end
 end)
 
+function M:setup(user_config)
+	apply_config(user_config)
+end
+
 local is_tree_view_mode = ya.sync(function(state, _)
+	get_or_init_state(state)
 	return state.tree
 end)
 
-local set_opts = ya.sync(function(state, opts)
-	if state.opts == nil then
-		state.opts = { level = 3, follow_symlinks = false, dereference = false, all = true }
-	end
-
-	for key, value in pairs(opts or {}) do
-		state.opts[key] = value
-	end
-end)
-
 local get_opts = ya.sync(function(state)
+	get_or_init_state(state)
 	return state.opts
 end)
 
+local toggle_view_mode = ya.sync(function(state, _)
+	get_or_init_state(state)
+	state.tree = not state.tree
+	ya.manager_emit("refresh", {})
+end)
+
 local inc_level = ya.sync(function(state)
+	get_or_init_state(state)
 	state.opts.level = state.opts.level + 1
+	ya.manager_emit("refresh", {})
 end)
 
 local dec_level = ya.sync(function(state)
+	get_or_init_state(state)
 	if state.opts.level > 1 then
 		state.opts.level = state.opts.level - 1
+		ya.manager_emit("refresh", {})
 	end
 end)
 
 local toggle_follow_symlinks = ya.sync(function(state)
+	get_or_init_state(state)
 	state.opts.follow_symlinks = not state.opts.follow_symlinks
+	ya.manager_emit("refresh", {})
 end)
 
 local toggle_hidden = ya.sync(function(state)
+	get_or_init_state(state)
 	state.opts.all = not state.opts.all
+	ya.manager_emit("refresh", {})
 end)
-
-function M:setup(opts)
-	set_opts(opts)
-
-	toggle_view_mode()
-end
 
 function M:entry(job)
 	local args = string.gsub(job.args[1] or "", "^%s*(.-)%s*$", "%1")
-
 	if args == "inc-level" then
 		inc_level()
 	elseif args == "dec-level" then
@@ -66,16 +82,14 @@ function M:entry(job)
 	elseif args == "toggle-hidden" then
 		toggle_hidden()
 	else
-		set_opts()
 		toggle_view_mode()
 	end
-
 	ya.manager_emit("seek", { 0 })
 end
 
 function M:peek(job)
 	local opts = get_opts()
-
+	local is_tree = is_tree_view_mode()
 	local args = {
 		"--color=always",
 		"--icons=always",
@@ -83,34 +97,27 @@ function M:peek(job)
 		"--no-quotes",
 		tostring(job.file.url),
 	}
-
-	if is_tree_view_mode() then
+	if is_tree then
 		table.insert(args, "--tree")
 		table.insert(args, string.format("--level=%d", opts.level))
 	end
-
 	if opts then
 		if opts.follow_symlinks then
 			table.insert(args, "--follow-symlinks")
 		end
-
 		if opts.all then
 			table.insert(args, "--all")
 		end
-
 		if opts.dereference then
 			table.insert(args, "--dereference")
 		end
 	end
-
 	local child = Command("eza"):arg(args):stdout(Command.PIPED):stderr(Command.PIPED):spawn()
-
 	local limit = job.area.h
 	local lines = ""
 	local num_lines = 1
 	local num_skip = 0
 	local empty_output = false
-
 	repeat
 		local line, event = child:read_line()
 		if event == 1 then
@@ -118,7 +125,6 @@ function M:peek(job)
 		elseif event ~= 0 then
 			break
 		end
-
 		if num_skip >= job.skip then
 			lines = lines .. line
 			num_lines = num_lines + 1
@@ -126,13 +132,11 @@ function M:peek(job)
 			num_skip = num_skip + 1
 		end
 	until num_lines >= limit
-
 	if num_lines == 1 and not is_tree_view_mode() then
 		empty_output = true
 	elseif num_lines == 2 and is_tree_view_mode() then
 		empty_output = true
 	end
-
 	child:start_kill()
 	if job.skip > 0 and num_lines < limit then
 		ya.manager_emit("peek", {
@@ -145,16 +149,16 @@ function M:peek(job)
 			ui.Text({ ui.Line("No items") }):area(job.area):align(ui.Text.CENTER),
 		})
 	else
-		ya.preview_widgets(job, { ui.Text.parse(lines):area(job.area) })
+		ya.preview_widgets(job, {
+			ui.Text.parse(lines):area(job.area),
+		})
 	end
 end
 
 function M:seek(job)
 	local h = cx.active.current.hovered
-
 	if h and h.url == job.file.url then
 		local step = math.floor(job.units * job.area.h / 10)
-
 		ya.manager_emit("peek", {
 			math.max(0, cx.active.preview.skip + step),
 			only_if = tostring(job.file.url),


### PR DESCRIPTION
This commit introduces the ability for users to configure the default preview mode (tree or list) and other options via their init.lua file.

To robustly support this new feature, the plugin's internal state management has been refactored. This refactoring also brings several key improvements:

- Fixes potential bugs related to inconsistent state initialization.
- Improves UI responsiveness by triggering a refresh after an option is toggled.
- Centralizes all default options, making future maintenance easier.

Already check all the settings is working in my local machine, please have a check.