### PR TITLE
<feat> Add ignore_glob configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ require("eza-preview"):setup({
   dereference = false,
 
   -- Show hidden files (default: true) 
-  all = true
+  all = true,
+
+  -- Ignore files matching patterns (default: {})
+  -- Can be a string or array of strings
+  ignore_glob = { "*.tmp", "node_modules", ".DS_Store" }
+  -- or
+  -- ignore_glob = "*.log"
 })
 
 -- Or use default settings
@@ -80,6 +86,43 @@ require("eza-preview"):setup({})
 - `plugin eza-preview toggle-follow-symlinks` - Toggle symlink following
 - `plugin eza-preview toggle-hidden` - Toggle hidden file visibility
 
+## Configuration Options
+
+### ignore_glob
+
+The `ignore_glob` option allows you to exclude specific files or patterns from the directory preview using glob patterns.
+
+**Examples:**
+
+```lua
+-- Single pattern
+ignore_glob = ".DS_Store"
+
+-- Multiple patterns
+ignore_glob = { ".DS_Store", "*.tmp", "node_modules" }
+
+-- Wildcard patterns
+ignore_glob = { "*.log", "*.bak", "temp*" }
+
+-- Directory patterns
+ignore_glob = { "node_modules", ".git", ".svn" }
+
+-- Mixed patterns
+ignore_glob = { ".DS_Store", "*.tmp", "node_modules", "*.pyc" }
+```
+
+**Supported glob patterns:**
+- `*` - Matches any characters
+- `?` - Matches any single character  
+- `[abc]` - Matches any character in brackets
+- Literal strings for exact matches
+
+**Common use cases:**
+- Hide system files: `{ ".DS_Store", "Thumbs.db" }`
+- Hide temporary files: `{ "*.tmp", "*.temp", "*~" }`
+- Hide build artifacts: `{ "node_modules", "target", "build", "dist" }`
+- Hide version control: `{ ".git", ".svn", ".hg" }`
+
 ## Contributing
 
 Feel free to contribute by opening issues or submitting pull requests!
@@ -87,4 +130,3 @@ Feel free to contribute by opening issues or submitting pull requests!
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-

--- a/main.lua
+++ b/main.lua
@@ -8,7 +8,7 @@ local function get_or_init_state(state)
 	if state.initialized then
 		return
 	end
-	state.opts = { level = 3, follow_symlinks = false, dereference = false, all = true }
+	state.opts = { level = 3, follow_symlinks = false, dereference = false, all = true, ignore_glob = {} }
 	state.tree = true
 	state.initialized = true
 end
@@ -110,6 +110,14 @@ function M:peek(job)
 		end
 		if opts.dereference then
 			table.insert(args, "--dereference")
+		end
+		if opts.ignore_glob and type(opts.ignore_glob) == "table" and #opts.ignore_glob > 0 then
+			local pattern_str = table.concat(opts.ignore_glob, "|")
+			table.insert(args, "-I")
+			table.insert(args, pattern_str)
+		elseif opts.ignore_glob and type(opts.ignore_glob) == "string" and opts.ignore_glob ~= "" then
+			table.insert(args, "-I")
+			table.insert(args, opts.ignore_glob)
 		end
 	end
 	local child = Command("eza"):arg(args):stdout(Command.PIPED):stderr(Command.PIPED):spawn()


### PR DESCRIPTION
# Add ignore_glob configuration option

## Summary

This pull request adds support for the `ignore_glob` configuration option, allowing users to exclude specific files or patterns from directory previews using eza's `--ignore-glob` functionality.

## Changes

### Features Added
- **New `ignore_glob` configuration option** that accepts:
  - Single string pattern: `ignore_glob = ".DS_Store"`
  - Array of patterns: `ignore_glob = { ".DS_Store", "*.tmp", "node_modules" }`

### Files Modified
- **main.lua**: Added ignore_glob support in the `get_or_init_state` and `M:peek` function
- **README.md**: Updated documentation with configuration examples and usage

### Technical Implementation
- Uses eza's `-I` flag (short form of `--ignore-glob`)
- Combines multiple patterns using pipe separator (`|`) as required by eza
- Handles both string and array input formats
- Gracefully ignores empty patterns

## Usage Example

```lua
require("eza-preview"):setup({
  ignore_glob = { ".DS_Store", "*.tmp", "node_modules", ".git" }
})
```

## Testing

- ✅ Tested with single string patterns
- ✅ Tested with multiple pattern arrays
- ✅ Tested with wildcard patterns (`*.tmp`, `*.log`)
- ✅ Tested with directory patterns (`node_modules`, `.git`)
- ✅ Tested edge cases (empty arrays, nil values, empty strings)
- ✅ Tested special characters and unicode filenames
- ✅ Tested integration with existing options
- ✅ Tested in both tree and list view modes
- ✅ Verified manual eza commands produce identical results

## Backward Compatibility

- ✅ Fully backward compatible
- ✅ Default behavior unchanged (empty ignore_glob array)
- ✅ All existing configurations continue to work
- ✅ No breaking changes to API

## Documentation

- ✅ Updated README.md with comprehensive examples
- ✅ Added configuration option documentation
- ✅ Included common use case examples
- ✅ Added supported glob pattern reference

## Related Issues

Resolves the need for filtering unwanted files from directory previews, commonly requested for:
- System files (`.DS_Store`, `Thumbs.db`)
- Temporary files (`*.tmp`, `*.temp`)
- Build artifacts (`node_modules`, `target`, `build`)
- Version control directories (`.git`, `.svn`)

## Additional Notes

The implementation uses eza's short flag format (`-I`) as it was found to work more reliably with Yazi's Command system compared to the long format (`--ignore-glob`). Multiple patterns are combined with the pipe separator (`|`) as required by eza's specification.
