### PR TITLE
fix: resolve ya.sync poll errors in yazi 25.12.29

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -2,96 +2,104 @@
 
 local M = {}
 
--- Module-level state (avoids ya.sync polling issues in async peek context)
-M._opts = {
-	level = 3,
-	follow_symlinks = true,
-	dereference = false,
-	all = true,
-	ignore_glob = {},
-	git_ignore = true,
-	git_status = false,
-	icons = true,
-}
-M._tree = true
+-- Sync getters - return simple values only (tables cause poll errors)
+local get_tree = ya.sync(function(st) return st.tree ~= false end)
+local get_level = ya.sync(function(st) return st.level or 3 end)
+local get_follow_symlinks = ya.sync(function(st) return st.follow_symlinks ~= false end)
+local get_dereference = ya.sync(function(st) return st.dereference == true end)
+local get_all = ya.sync(function(st) return st.all ~= false end)
+local get_git_ignore = ya.sync(function(st) return st.git_ignore ~= false end)
+local get_git_status = ya.sync(function(st) return st.git_status == true end)
+local get_icons = ya.sync(function(st) return st.icons ~= false end)
+local get_ignore_glob = ya.sync(function(st) return st.ignore_glob or "" end)
 
-local function fail(s, ...)
-	ya.notify({ title = "Eza Preview", content = string.format(s, ...), timeout = 5, level = "error" })
-end
+-- Sync setters (also trigger preview refresh)
+local set_tree = ya.sync(function(st, val)
+	st.tree = val
+	local h = cx.active.current.hovered
+	if h then ya.emit("peek", { 0, only_if = h.url, force = true }) end
+end)
+local set_level = ya.sync(function(st, val)
+	st.level = val
+	local h = cx.active.current.hovered
+	if h then ya.emit("peek", { 0, only_if = h.url, force = true }) end
+end)
+local set_follow_symlinks = ya.sync(function(st, val)
+	st.follow_symlinks = val
+	local h = cx.active.current.hovered
+	if h then ya.emit("peek", { 0, only_if = h.url, force = true }) end
+end)
+local set_all = ya.sync(function(st, val)
+	st.all = val
+	local h = cx.active.current.hovered
+	if h then ya.emit("peek", { 0, only_if = h.url, force = true }) end
+end)
+local set_git_ignore = ya.sync(function(st, val)
+	st.git_ignore = val
+	local h = cx.active.current.hovered
+	if h then ya.emit("peek", { 0, only_if = h.url, force = true }) end
+end)
+local set_git_status = ya.sync(function(st, val)
+	st.git_status = val
+	local h = cx.active.current.hovered
+	if h then ya.emit("peek", { 0, only_if = h.url, force = true }) end
+end)
 
-function M:setup(user_config)
-	user_config = user_config or {}
-	for key, value in pairs(user_config) do
-		if key == "default_tree" then
-			M._tree = value
-		elseif M._opts[key] ~= nil then
-			M._opts[key] = value
+-- Setup from user config
+local apply_config = ya.sync(function(st, cfg)
+	cfg = cfg or {}
+	if cfg.default_tree ~= nil then st.tree = cfg.default_tree end
+	if cfg.level ~= nil then st.level = cfg.level end
+	if cfg.follow_symlinks ~= nil then st.follow_symlinks = cfg.follow_symlinks end
+	if cfg.dereference ~= nil then st.dereference = cfg.dereference end
+	if cfg.all ~= nil then st.all = cfg.all end
+	if cfg.git_ignore ~= nil then st.git_ignore = cfg.git_ignore end
+	if cfg.git_status ~= nil then st.git_status = cfg.git_status end
+	if cfg.icons ~= nil then st.icons = cfg.icons end
+	if cfg.ignore_glob ~= nil then
+		if type(cfg.ignore_glob) == "table" then
+			st.ignore_glob = table.concat(cfg.ignore_glob, "|")
+		else
+			st.ignore_glob = cfg.ignore_glob
 		end
 	end
+end)
+
+function M:setup(cfg)
+	apply_config(cfg)
 end
-
--- Sync blocks for entry point mutations only (not called from async peek)
-local toggle_view_mode = ya.sync(function()
-	M._tree = not M._tree
-	ya.manager_emit("refresh", {})
-end)
-
-local inc_level = ya.sync(function()
-	M._opts.level = M._opts.level + 1
-	ya.manager_emit("refresh", {})
-end)
-
-local dec_level = ya.sync(function()
-	if M._opts.level > 1 then
-		M._opts.level = M._opts.level - 1
-		ya.manager_emit("refresh", {})
-	end
-end)
-
-local toggle_follow_symlinks = ya.sync(function()
-	M._opts.follow_symlinks = not M._opts.follow_symlinks
-	ya.manager_emit("refresh", {})
-end)
-
-local toggle_hidden = ya.sync(function()
-	M._opts.all = not M._opts.all
-	ya.manager_emit("refresh", {})
-end)
-
-local toggle_git_ignore = ya.sync(function()
-	M._opts.git_ignore = not M._opts.git_ignore
-	ya.manager_emit("refresh", {})
-end)
-
-local toggle_git_status = ya.sync(function()
-	M._opts.git_status = not M._opts.git_status
-	ya.manager_emit("refresh", {})
-end)
 
 function M:entry(job)
 	local args = string.gsub(job.args[1] or "", "^%s*(.-)%s*$", "%1")
 	if args == "inc-level" then
-		inc_level()
+		set_level(get_level() + 1)
 	elseif args == "dec-level" then
-		dec_level()
+		local lvl = get_level()
+		if lvl > 1 then set_level(lvl - 1) end
 	elseif args == "toggle-follow-symlinks" then
-		toggle_follow_symlinks()
+		set_follow_symlinks(not get_follow_symlinks())
 	elseif args == "toggle-hidden" then
-		toggle_hidden()
+		set_all(not get_all())
 	elseif args == "toggle-git-ignore" then
-		toggle_git_ignore()
+		set_git_ignore(not get_git_ignore())
 	elseif args == "toggle-git-status" then
-		toggle_git_status()
+		set_git_status(not get_git_status())
 	else
-		toggle_view_mode()
+		set_tree(not get_tree())
 	end
-	ya.manager_emit("seek", { 0 })
 end
 
 function M:peek(job)
-	-- Access module-level state directly (no ya.sync call from async context)
-	local opts = M._opts
-	local is_tree = M._tree
+	local is_tree = get_tree()
+	local level = get_level()
+	local follow_symlinks = get_follow_symlinks()
+	local dereference = get_dereference()
+	local all = get_all()
+	local git_ignore = get_git_ignore()
+	local git_status = get_git_status()
+	local icons = get_icons()
+	local ignore_glob = get_ignore_glob()
+
 	local args = {
 		"--color=always",
 		"--group-directories-first",
@@ -100,55 +108,52 @@ function M:peek(job)
 	}
 	if is_tree then
 		table.insert(args, "--tree")
-		table.insert(args, string.format("--level=%d", opts.level))
+		table.insert(args, string.format("--level=%d", level))
 	end
-	if opts then
-		if opts.icons then
-			table.insert(args, "--icons=always")
-		end
-		if opts.follow_symlinks then
-			table.insert(args, "--follow-symlinks")
-		end
-		if opts.all then
-			table.insert(args, "--all")
-		end
-		if opts.dereference then
-			table.insert(args, "--dereference")
-		end
-		if opts.git_status then
-			table.insert(args, "--long")
-			table.insert(args, "--no-permissions")
-			table.insert(args, "--no-user")
-			table.insert(args, "--no-time")
-			table.insert(args, "--no-filesize")
-			table.insert(args, "--git")
-			table.insert(args, "--git-repos")
-		end
-		if opts.git_ignore then
-			table.insert(args, "--git-ignore")
-		end
-		if opts.ignore_glob and type(opts.ignore_glob) == "table" and #opts.ignore_glob > 0 then
-			local pattern_str = table.concat(opts.ignore_glob, "|")
-			table.insert(args, "-I")
-			table.insert(args, pattern_str)
-		elseif opts.ignore_glob and type(opts.ignore_glob) == "string" and opts.ignore_glob ~= "" then
-			table.insert(args, "-I")
-			table.insert(args, opts.ignore_glob)
-		end
+	if icons then
+		table.insert(args, "--icons=always")
 	end
+	if follow_symlinks then
+		table.insert(args, "--follow-symlinks")
+	end
+	if all then
+		table.insert(args, "--all")
+	end
+	if dereference then
+		table.insert(args, "--dereference")
+	end
+	if git_status then
+		table.insert(args, "--long")
+		table.insert(args, "--no-permissions")
+		table.insert(args, "--no-user")
+		table.insert(args, "--no-time")
+		table.insert(args, "--no-filesize")
+		table.insert(args, "--git")
+		table.insert(args, "--git-repos")
+	end
+	if git_ignore then
+		table.insert(args, "--git-ignore")
+	end
+	if ignore_glob ~= "" then
+		table.insert(args, "-I")
+		table.insert(args, ignore_glob)
+	end
+
 	local child, err = Command("eza"):arg(args):stdout(Command.PIPED):stderr(Command.PIPED):spawn()
 	if not child then
 		return ya.preview_widget(job, ui.Text("eza: " .. (err or "spawn failed")):area(job.area))
 	end
+
 	local limit = job.area.h
 	local lines = ""
 	local num_lines = 1
 	local num_skip = 0
 	local empty_output = false
+
 	repeat
 		local line, event = child:read_line()
 		if event == 1 then
-			fail(tostring(event))
+			ya.notify({ title = "Eza Preview", content = "stderr: " .. tostring(line), timeout = 5, level = "error" })
 		elseif event ~= 0 then
 			break
 		end
@@ -159,17 +164,20 @@ function M:peek(job)
 			num_skip = num_skip + 1
 		end
 	until num_lines >= limit
+
 	if num_lines == 1 and not is_tree then
 		empty_output = true
 	elseif num_lines == 2 and is_tree then
 		empty_output = true
 	end
+
 	child:start_kill()
+
 	if job.skip > 0 and num_lines < limit then
-		ya.manager_emit("peek", {
-			tostring(math.max(0, job.skip - (limit - num_lines))),
-			only_if = tostring(job.file.url),
-			upper_bound = "",
+		ya.emit("peek", {
+			math.max(0, job.skip - (limit - num_lines)),
+			only_if = job.file.url,
+			upper_bound = true,
 		})
 	elseif empty_output then
 		ya.preview_widget(job, {
@@ -186,9 +194,9 @@ function M:seek(job)
 	local h = cx.active.current.hovered
 	if h and h.url == job.file.url then
 		local step = math.floor(job.units * job.area.h / 10)
-		ya.manager_emit("peek", {
+		ya.emit("peek", {
 			math.max(0, cx.active.preview.skip + step),
-			only_if = tostring(job.file.url),
+			only_if = job.file.url,
 			force = true,
 		})
 	end


### PR DESCRIPTION
Move state from ya.sync-managed objects to module-level variables. Calling ya.sync blocks from async peek context causes poll errors after yazi's actor model refactor.

- Use M._opts and M._tree for state instead of sync block access
- Keep ya.sync only for entry point mutations (toggle operations)
- Add spawn error handling for eza command
- Update ya.err to ya.notify API

Fixes #8