### PR TITLE
fix: align preview text with ui.Align.CENTER

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tree mode:
 
 ## Requirements
 
-- [yazi (25.12+) or nightly](h;nottps://github.com/sxyazi/yazi)
+- [yazi (26.1.4+) or nightly](https://github.com/sxyazi/yazi)
 - [eza (0.20+)](https://github.com/eza-community/eza)
 
 ## Installation

--- a/main.lua
+++ b/main.lua
@@ -179,7 +179,7 @@ function M:peek(job)
 		})
 	elseif empty_output then
 		ya.preview_widget(job, {
-			ui.Text({ ui.Line("No items") }):area(job.area):align(ui.Text.CENTER),
+			ui.Text({ ui.Line("No items") }):area(job.area):align(ui.Align.CENTER),
 		})
 	else
 		ya.preview_widget(job, {


### PR DESCRIPTION
Fixes Yazi 26.x crash in previewer: replace ui.Text.CENTER with ui.Align.CENTER to avoid nil Align error.